### PR TITLE
Fixes a compile error on Windows, removes an unused import

### DIFF
--- a/src/com/jamesshore/spikes/mac_laf/MacSpike.java
+++ b/src/com/jamesshore/spikes/mac_laf/MacSpike.java
@@ -4,7 +4,6 @@ import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
 import javax.swing.table.*;
-import com.apple.eawt.*;
 
 @SuppressWarnings("unused")
 public class MacSpike extends JFrame {


### PR DESCRIPTION
There was an unused import com.apple.eawt.\* which makes it not possible to compile the project on non-Mac platforms.
